### PR TITLE
Add simple PHP gastro bar ordering app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# BeerHouse
+# BeerHouse - Gastro Bar Orders
+
+Aplicación web sencilla para registrar pedidos en un gastro bar utilizando PHP puro y SQLite. Permite guardar información de los clientes y sus pedidos, exportar los pedidos diarios en CSV y generar un reporte PDF.
+
+## Uso rápido
+1. Asegúrate de tener PHP con soporte para SQLite.
+2. Coloca todos los archivos en un servidor que ejecute PHP.
+3. Accede a `index.php` desde tu navegador.
+4. Ingresa los pedidos mediante el formulario.
+5. Usa los enlaces "Exportar CSV" y "Reporte PDF" para obtener los pedidos del día.
+
+El PDF se genera sin librerías externas mediante un generador básico incluido en `export_pdf.php`.

--- a/db.php
+++ b/db.php
@@ -1,0 +1,37 @@
+<?php
+function getDB() {
+    static $db = null;
+    if ($db === null) {
+        $db = new PDO('sqlite:database.db');
+        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    }
+    return $db;
+}
+
+function createTables() {
+    $db = getDB();
+    $db->exec("CREATE TABLE IF NOT EXISTS orders (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT,
+        phone TEXT,
+        item TEXT,
+        qty INTEGER,
+        price REAL,
+        created_at TEXT
+    )");
+}
+
+function addOrder($name, $phone, $item, $qty, $price) {
+    $db = getDB();
+    $stmt = $db->prepare("INSERT INTO orders (name, phone, item, qty, price, created_at)
+                          VALUES (?, ?, ?, ?, ?, datetime('now'))");
+    $stmt->execute([$name, $phone, $item, $qty, $price]);
+}
+
+function getTodayOrders() {
+    $db = getDB();
+    $today = date('Y-m-d');
+    $stmt = $db->prepare("SELECT * FROM orders WHERE date(created_at)=? ORDER BY created_at DESC");
+    $stmt->execute([$today]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}

--- a/export_csv.php
+++ b/export_csv.php
@@ -1,0 +1,21 @@
+<?php
+require_once 'db.php';
+
+$orders = getTodayOrders();
+$filename = 'orders_' . date('Ymd') . '.csv';
+header('Content-Type: text/csv');
+header('Content-Disposition: attachment; filename=' . $filename);
+
+$out = fopen('php://output', 'w');
+fputcsv($out, ['Hora','Cliente','Teléfono','Item','Cantidad','Precio']);
+foreach ($orders as $o) {
+    fputcsv($out, [
+        date('H:i', strtotime($o['created_at'])),
+        $o['name'],
+        $o['phone'],
+        $o['item'],
+        $o['qty'],
+        number_format($o['price'], 2)
+    ]);
+}
+ fclose($out);

--- a/export_pdf.php
+++ b/export_pdf.php
@@ -2,56 +2,44 @@
 require_once 'db.php';
 
 function simplePDF($orders) {
-    $pdf = "%PDF-1.4\n";
     $objects = [];
-    $pages = [];
-    $currentObject = 1;
+    $objNum = 1;
 
-    // fonts object
-    $objects[] = "$currentObject 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n";
-    $fontObj = $currentObject;
-    $currentObject++;
+    $fontObj = $objNum++;
+    $objects[$fontObj] = "$fontObj 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n";
 
-    // page content
-    $content = "BT\n/F1 12 Tf\n50 750 Td\n(Tabla de pedidos) Tj\n";
-    $y = 720;
+    $content = "BT\n/F1 12 Tf\n1 0 0 1 50 750 Tm (Tabla de pedidos) Tj\n";
+    $y = 730;
     foreach ($orders as $o) {
+        $y -= 20;
         $line = sprintf('%s %s %s %s x%s $%0.2f',
             date('H:i', strtotime($o['created_at'])),
             $o['name'], $o['phone'], $o['item'], $o['qty'], $o['price']);
-        $content .= sprintf("50 %d Td (%s) Tj\n", $y, str_replace(['(',')','\\'],['\\(','\\)','\\\\'],$line));
-        $y -= 20;
+        $safe = str_replace(['(',')','\\'], ['\\(','\\)','\\\\'], $line);
+        $content .= "1 0 0 1 50 $y Tm ($safe) Tj\n";
     }
     $content .= "ET";
 
-    $objects[] = "$currentObject 0 obj\n<< /Length " . strlen($content) . " >>\nstream\n$content\nendstream\nendobj\n";
-    $contentObj = $currentObject;
-    $currentObject++;
+    $contentObj = $objNum++;
+    $objects[$contentObj] = "$contentObj 0 obj\n<< /Length " . strlen($content) . " >>\nstream\n$content\nendstream\nendobj\n";
 
-    // page object
-    $objects[] = "$currentObject 0 obj\n<< /Type /Page /Parent 0 0 R /MediaBox [0 0 595 842] /Contents $contentObj 0 R /Resources << /Font << /F1 $fontObj 0 R >> >> >>\nendobj\n";
-    $pageObj = $currentObject;
-    $currentObject++;
-    $pages[] = $pageObj;
+    $pageObj = $objNum++;
+    $pagesObj = $objNum; // next object number
+    $objects[$pageObj] = "$pageObj 0 obj\n<< /Type /Page /Parent $pagesObj 0 R /MediaBox [0 0 595 842] /Contents $contentObj 0 R /Resources << /Font << /F1 $fontObj 0 R >> >> >>\nendobj\n";
 
-    // pages object
-    $kids = implode(' 0 R ', $pages) . ' 0 R';
-    $objects[] = "$currentObject 0 obj\n<< /Type /Pages /Kids [ $kids ] /Count " . count($pages) . " >>\nendobj\n";
-    $pagesObj = $currentObject;
-    $currentObject++;
+    $objects[$pagesObj] = "$pagesObj 0 obj\n<< /Type /Pages /Kids [ $pageObj 0 R ] /Count 1 >>\nendobj\n";
+    $objNum++;
 
-    // catalog object
-    $objects[] = "$currentObject 0 obj\n<< /Type /Catalog /Pages $pagesObj 0 R >>\nendobj\n";
-    $catalogObj = $currentObject;
-    $currentObject++;
+    $catalogObj = $objNum++;
+    $objects[$catalogObj] = "$catalogObj 0 obj\n<< /Type /Catalog /Pages $pagesObj 0 R >>\nendobj\n";
 
-    // xref
-    $xref = "xref\n0 $currentObject\n0000000000 65535 f \n";
+    $pdf = "%PDF-1.4\n";
+    $xref = "xref\n0 $objNum\n0000000000 65535 f \n";
     $offsets = []; $pos = strlen($pdf);
-    foreach ($objects as $obj) { $offsets[] = $pos; $pdf .= $obj; $pos += strlen($obj); }
+    for ($i = 1; $i < $objNum; $i++) { $offsets[] = $pos; $pdf .= $objects[$i]; $pos += strlen($objects[$i]); }
     foreach ($offsets as $off) { $xref .= sprintf("%010d 00000 n \n", $off); }
     $pdf .= $xref;
-    $pdf .= "trailer\n<< /Size $currentObject /Root $catalogObj 0 R >>\nstartxref\n" . $pos . "\n%%EOF";
+    $pdf .= "trailer\n<< /Size $objNum /Root $catalogObj 0 R >>\nstartxref\n" . $pos . "\n%%EOF";
 
     return $pdf;
 }

--- a/export_pdf.php
+++ b/export_pdf.php
@@ -1,0 +1,64 @@
+<?php
+require_once 'db.php';
+
+function simplePDF($orders) {
+    $pdf = "%PDF-1.4\n";
+    $objects = [];
+    $pages = [];
+    $currentObject = 1;
+
+    // fonts object
+    $objects[] = "$currentObject 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n";
+    $fontObj = $currentObject;
+    $currentObject++;
+
+    // page content
+    $content = "BT\n/F1 12 Tf\n50 750 Td\n(Tabla de pedidos) Tj\n";
+    $y = 720;
+    foreach ($orders as $o) {
+        $line = sprintf('%s %s %s %s x%s $%0.2f',
+            date('H:i', strtotime($o['created_at'])),
+            $o['name'], $o['phone'], $o['item'], $o['qty'], $o['price']);
+        $content .= sprintf("50 %d Td (%s) Tj\n", $y, str_replace(['(',')','\\'],['\\(','\\)','\\\\'],$line));
+        $y -= 20;
+    }
+    $content .= "ET";
+
+    $objects[] = "$currentObject 0 obj\n<< /Length " . strlen($content) . " >>\nstream\n$content\nendstream\nendobj\n";
+    $contentObj = $currentObject;
+    $currentObject++;
+
+    // page object
+    $objects[] = "$currentObject 0 obj\n<< /Type /Page /Parent 0 0 R /MediaBox [0 0 595 842] /Contents $contentObj 0 R /Resources << /Font << /F1 $fontObj 0 R >> >> >>\nendobj\n";
+    $pageObj = $currentObject;
+    $currentObject++;
+    $pages[] = $pageObj;
+
+    // pages object
+    $kids = implode(' 0 R ', $pages) . ' 0 R';
+    $objects[] = "$currentObject 0 obj\n<< /Type /Pages /Kids [ $kids ] /Count " . count($pages) . " >>\nendobj\n";
+    $pagesObj = $currentObject;
+    $currentObject++;
+
+    // catalog object
+    $objects[] = "$currentObject 0 obj\n<< /Type /Catalog /Pages $pagesObj 0 R >>\nendobj\n";
+    $catalogObj = $currentObject;
+    $currentObject++;
+
+    // xref
+    $xref = "xref\n0 $currentObject\n0000000000 65535 f \n";
+    $offsets = []; $pos = strlen($pdf);
+    foreach ($objects as $obj) { $offsets[] = $pos; $pdf .= $obj; $pos += strlen($obj); }
+    foreach ($offsets as $off) { $xref .= sprintf("%010d 00000 n \n", $off); }
+    $pdf .= $xref;
+    $pdf .= "trailer\n<< /Size $currentObject /Root $catalogObj 0 R >>\nstartxref\n" . $pos . "\n%%EOF";
+
+    return $pdf;
+}
+
+$orders = getTodayOrders();
+$pdf = simplePDF($orders);
+header('Content-Type: application/pdf');
+header('Content-Disposition: attachment; filename="orders_' . date('Ymd') . '.pdf"');
+header('Content-Length: ' . strlen($pdf));
+echo $pdf;

--- a/index.php
+++ b/index.php
@@ -1,0 +1,82 @@
+<?php
+require_once 'db.php';
+
+createTables();
+
+$errors = [];
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    $phone = trim($_POST['phone'] ?? '');
+    $item = trim($_POST['item'] ?? '');
+    $qty = (int)($_POST['qty'] ?? 1);
+    $price = (float)($_POST['price'] ?? 0);
+
+    if (!$name || !$item) {
+        $errors[] = 'Nombre e item son requeridos';
+    } else {
+        addOrder($name, $phone, $item, $qty, $price);
+        header('Location: index.php');
+        exit;
+    }
+}
+
+$orders = getTodayOrders();
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Gastro Bar</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>Pedidos Gastro Bar</h1>
+<form method="post" class="order-form">
+    <h2>Nuevo Pedido</h2>
+    <?php if ($errors): ?>
+        <div class="error">
+            <?php foreach ($errors as $e) echo "<p>$e</p>"; ?>
+        </div>
+    <?php endif; ?>
+    <label>Nombre Cliente
+        <input type="text" name="name" required>
+    </label>
+    <label>Teléfono
+        <input type="text" name="phone">
+    </label>
+    <label>Item
+        <input type="text" name="item" required>
+    </label>
+    <label>Cantidad
+        <input type="number" name="qty" value="1" min="1">
+    </label>
+    <label>Precio
+        <input type="number" name="price" value="0" step="0.01" min="0">
+    </label>
+    <button type="submit">Agregar</button>
+</form>
+
+<h2>Pedidos de hoy</h2>
+<table>
+    <thead>
+        <tr><th>Hora</th><th>Cliente</th><th>Teléfono</th><th>Item</th><th>Cant</th><th>Precio</th></tr>
+    </thead>
+    <tbody>
+        <?php foreach ($orders as $o): ?>
+            <tr>
+                <td><?=htmlspecialchars(date('H:i', strtotime($o['created_at'])))?></td>
+                <td><?=htmlspecialchars($o['name'])?></td>
+                <td><?=htmlspecialchars($o['phone'])?></td>
+                <td><?=htmlspecialchars($o['item'])?></td>
+                <td><?=htmlspecialchars($o['qty'])?></td>
+                <td><?=htmlspecialchars(number_format($o['price'], 2))?></td>
+            </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<div class="actions">
+    <a href="export_csv.php" class="button">Exportar CSV</a>
+    <a href="export_pdf.php" class="button">Reporte PDF</a>
+</div>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,50 @@
+body {
+    font-family: Arial, sans-serif;
+    background: #fdf6e3;
+    color: #333;
+    margin: 0;
+    padding: 1em;
+}
+h1 {
+    color: #4a4a4a;
+    font-family: 'Courier New', Courier, monospace;
+}
+.order-form {
+    background: #ffe8e8;
+    padding: 1em;
+    border-radius: 5px;
+    margin-bottom: 2em;
+}
+.order-form label {
+    display: block;
+    margin-bottom: 0.5em;
+}
+.order-form input {
+    padding: 0.3em;
+    width: 100%;
+    margin-top: 0.2em;
+}
+button, .button {
+    background: #ffb6c1;
+    border: none;
+    padding: 0.5em 1em;
+    color: #333;
+    text-decoration: none;
+    border-radius: 3px;
+    font-weight: bold;
+}
+button:hover, .button:hover {
+    background: #ffc8d2;
+}
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+th, td {
+    border: 1px solid #ccc;
+    padding: 0.5em;
+}
+.actions {
+    margin-top: 1em;
+}
+.error {color: red;}


### PR DESCRIPTION
## Summary
- create main page `index.php` with a form and list of today's orders
- store orders in an SQLite database via `db.php`
- export daily orders to CSV with `export_csv.php`
- generate a minimal PDF report with `export_pdf.php`
- add pastel retro styles in `style.css`
- update README with usage instructions

## Testing
- `php` command not available: **Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.**

------
https://chatgpt.com/codex/tasks/task_e_6866f2f4cbcc8329afcece4f0a8e6b1c